### PR TITLE
Use '--ignore_not_exists' for removing opsiHostId

### DIFF
--- a/99opsi4ucs.inst
+++ b/99opsi4ucs.inst
@@ -133,7 +133,7 @@ $VERBOSE && echo "     Windomain        : $WINDOMAIN"
 
 ## --- Deleting existing opsi extended-attribute ------------------------------------------------------------------------
 udm settings/extended_attribute remove "$@" \
-	--dn="cn=opsiHostId,cn=custom attributes,cn=univention,$ROOT_DN" 2>/dev/null || true
+	--dn="cn=opsiHostId,cn=custom attributes,cn=univention,$ROOT_DN" --ignore_not_exists
 
 # --- Add users and groups ------------------------------------------------------------------------------------------------------
 $VERBOSE && echo "Adding system users and groups..."


### PR DESCRIPTION
I just stumbled upon this while going through the `join.log` of a new opsi installation on UCS. The following command trys to remove an (old?) extended attribute that might exist from earlier versions:

```
udm settings/extended_attribute remove "$@" \
    --dn="cn=opsiHostId,cn=custom attributes,cn=univention,$ROOT_DN" 2>/dev/null || true
```

If the extended attribute does not exist (which is the default), `udm` will always return an error (and a non-zero exitcode):
```
E: object not found
```
But not being able to remove an object because it does not exist, should not be counted as an error.
When using `--ignore_not_exists` as additional parameter, `udm` will not return an error, but only an info:
```
Object not found: cn=opsiHostId,cn=custom attributes,cn=univention,dc=example,dc=org
```
And the exitcode will be `0` :)



